### PR TITLE
kotlin version upgrade, dependencies version upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,14 @@
 buildscript {
 
   ext.versions = [
-      'coroutines': '0.25.0',
-      'kotlin': '1.2.61',
-      'ktor': '0.9.4',
-      'moshi': '1.6.0'
+      'kotlin': '1.3.10',
+      'ktor': '1.0.0',
+      'moshi': '1.8.0',
+      'okio': '2.1.0'
   ]
 
   ext.deps = [
       'kotlin': [
-          'coroutines': "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}",
           'stdlib': "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}",
       ],
       'ktor': [
@@ -26,7 +25,7 @@ buildscript {
           'kotlin': "com.squareup.moshi:moshi-kotlin:${versions.moshi}",
           'codegen': "com.squareup.moshi:moshi-kotlin-codegen:${versions.moshi}"
       ],
-      'okio': "com.squareup.okio:okio:2.0.0"
+      'okio': "com.squareup.okio:okio:${versions.okio}",
   ]
 
   repositories {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-kapt'
 
-kotlin.experimental.coroutines 'enable'
-
 dependencies {
   compile deps.kotlin.stdlib
   compile deps.ktor.server
@@ -11,7 +9,6 @@ dependencies {
 
   testCompile deps.junit
   testCompile deps.truth
-  testCompile deps.kotlin.coroutines
   testCompile deps.kotlin.stdlib
   testCompile deps.ktor.test
   kaptTest deps.moshi.codegen

--- a/library/src/main/kotlin/com/ryanharter/ktor/moshi/MoshiConverter.kt
+++ b/library/src/main/kotlin/com/ryanharter/ktor/moshi/MoshiConverter.kt
@@ -11,9 +11,8 @@ import io.ktor.http.content.TextContent
 import io.ktor.http.withCharset
 import io.ktor.request.ApplicationReceiveRequest
 import io.ktor.util.pipeline.PipelineContext
-import kotlinx.coroutines.experimental.io.ByteReadChannel
-import kotlinx.coroutines.experimental.io.jvm.javaio.toInputStream
-import okio.Okio
+import kotlinx.coroutines.io.ByteReadChannel
+import kotlinx.coroutines.io.jvm.javaio.toInputStream
 import okio.buffer
 import okio.source
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,8 +8,6 @@ sourceCompatibility = 1.8
 compileKotlin.kotlinOptions.jvmTarget = "1.8"
 compileTestKotlin.kotlinOptions.jvmTarget = "1.8"
 
-kotlin.experimental.coroutines 'enable'
-
 dependencies {
   compile deps.kotlin.stdlib
   compile deps.ktor.netty


### PR DESCRIPTION
Hi. I was unable to use this because of okio 2.0.0, so I updated it and also bumped other dependencies versions (including kotlin).